### PR TITLE
Calendar: Swap touch gesture for navigating between weeks

### DIFF
--- a/app/src/views/Calendar.vue
+++ b/app/src/views/Calendar.vue
@@ -93,8 +93,8 @@
                 speedDial: false,
                 newEvent:  {},
                 touch:     {
-                    left:  () => this.previousWeek(),
-                    right: () => this.nextWeek(),
+                    left:  () => this.nextWeek(),
+                    right: () => this.previousWeek(),
                 },
             };
         },

--- a/app/src/views/TransfersList.vue
+++ b/app/src/views/TransfersList.vue
@@ -61,8 +61,8 @@
                 endDate:   null,
 
                 touch: {
-                    left:  () => this.previousMonth(),
-                    right: () => this.nextMonth(),
+                    left:  () => this.nextMonth(),
+                    right: () => this.previousMonth(),
                 },
             };
         },


### PR DESCRIPTION
This changes the direction the user has to swipe, in order to navigate between weeks on the calendar page. 

On master the user currently has to swipe from left to right in order to go forwards in time. (Moving the finger towards the direction he'd like go.) 

This is not intuitive as most applications dealing with calendars have the user swipe the current content away from the direction they'd like to go. 