### PR TITLE
Add apple touch icon

### DIFF
--- a/app/public/index.html
+++ b/app/public/index.html
@@ -6,6 +6,7 @@
     <meta name="viewport" content="width=device-width,initial-scale=1.0">
     <meta name="robots" content="noindex,noimageindex,noarchive,nosnippet,nofollow,nocache">
     <link rel="icon" href="<%= BASE_URL %>favicon.ico">
+    <link rel="apple-touch-icon" href="<%= BASE_URL %>img/logo192.png">
     <title><%- process.env.VUE_APP_BRANDING_TITLE %></title>
 </head>
 <body>


### PR DESCRIPTION
Use logo for Homescreen Touch Icon. Size 192 roughly matches Apple's highest pixel density devices, downscaling works very well on other iOS devices.